### PR TITLE
Added method to verify class to prevent overlapping ships bug

### DIFF
--- a/lib/main_menu.rb
+++ b/lib/main_menu.rb
@@ -62,7 +62,7 @@ class MainMenu
     submarine_array << submarine[3..4]
 
     #while user input coordinates are invalid, get new user input
-    while @verify.submarine_placement_coordinates(submarine_array) == false
+    while @verify.submarine_placement_coordinates(submarine_array) == false || @verify.verify_no_overlap(cruiser_array, submarine_array) == true
       p "Those are invalid coordinates. Please try again: "
       p ">"
       submarine = gets.chomp!

--- a/lib/verify.rb
+++ b/lib/verify.rb
@@ -31,4 +31,8 @@ class Verify
     end
   end
 
+  def verify_no_overlap(cruiser_coords, submarine_coords)
+    cruiser_coords.any?{|coord| coord == submarine_coords[0] || coord == submarine_coords[1]}
+  end
+
 end#Verify


### PR DESCRIPTION
verify_no_overlap method added to Verify class to prevent user from being able to overlap their ship placement.

implemented in setup_user